### PR TITLE
Fix version check matching wrong information

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,7 +13,7 @@
   register: terraform_directory
 
 - name: Check terraform version
-  shell: "terraform --version 2>&1 | grep {{terraform_version}}"
+  shell: "terraform --version 2>&1 | head -n 1 | grep {{terraform_version}}"
   failed_when: false
   changed_when: false
   register: terraform_versions_match


### PR DESCRIPTION
When I specify the most recent terraform version and run the role it doesn't upgrade because the version check grep matches the 0.12.3 later on in the `terraform --version` command that is just providing information.

My solution is to only check the first line.

```
$ terraform --version
Terraform v0.12.2

Your version of Terraform is out of date! The latest version
is 0.12.3. You can update by downloading from www.terraform.io/downloads.html
```